### PR TITLE
Adding GIMP and Inkscape profiles

### DIFF
--- a/gimp.conf
+++ b/gimp.conf
@@ -1,0 +1,4 @@
+{ "/usr/bin/gimp": {
+    "flags": "m"
+  }
+}

--- a/gimp.json
+++ b/gimp.json
@@ -1,0 +1,35 @@
+{
+"name": "gimp"
+,"path": "/usr/bin/gimp-2.8"
+, "allow_files": true
+, "paths": [
+	"/usr/bin/gimp"
+]
+, "xserver": {
+	"enabled": true
+	, "enable_tray": false
+	, "tray_icon":"/usr/share/icons/hicolor/scalable/apps/gimp.svg"
+}
+, "networking":{
+	"type":"empty"
+}
+, "whitelist": [
+	{"path":"${HOME}/.gimp-2.8", "can_create":true}
+	, {"path":"${HOME}/.fonts", "read_only":true}
+	, {"path":"${HOME}/Documents", "can_create":true}
+	, {"path":"${HOME}/Pictures", "can_create":true}
+	, {"path":"/tmp", "can_create":true}
+	, {"path":"/etc/gimp", "read_only": true, "ignore": true}
+	, {"path":"/usr/share/gimp", "read_only":true}
+]
+, "blacklist": [
+]
+, "environment": [
+	{"name":"GTK_THEME", "value":"Adwaita:dark"}
+	, {"name":"GTK2_RC_FILES", "value":"/usr/share/themes/Adwaita-dark/gtk-2.0/gtkrc"}
+]
+, "seccomp": {
+	"mode":"blacklist"
+	, "enforce": true
+}
+}

--- a/gimp.json
+++ b/gimp.json
@@ -18,7 +18,6 @@
 	, {"path":"${HOME}/.fonts", "read_only":true}
 	, {"path":"${HOME}/Documents", "can_create":true}
 	, {"path":"${HOME}/Pictures", "can_create":true}
-	, {"path":"/tmp", "can_create":true}
 	, {"path":"/etc/gimp", "read_only": true, "ignore": true}
 	, {"path":"/usr/share/gimp", "read_only":true}
 ]

--- a/inkscape.json
+++ b/inkscape.json
@@ -1,0 +1,32 @@
+{
+"name": "inkscape"
+,"path": "/usr/bin/inkscape"
+, "allow_files": true
+, "xserver": {
+	"enabled": true
+	, "enable_tray": false
+	, "tray_icon":"/usr/share/icons/hicolor/scalable/apps/inkscape.svg"
+}
+, "networking":{
+	"type":"empty"
+}
+, "whitelist": [
+	{"path":"${HOME}/.config/inkscape", "can_create":true}
+	, {"path":"${HOME}/.cache/inkscape", "can_create":true}
+	, {"path":"${HOME}/.fonts", "read_only":true}
+	, {"path":"${HOME}/Documents", "can_create":true}
+	, {"path":"${HOME}/Pictures", "can_create":true}
+	, {"path":"/usr/lib/inkscape", "read_only":true}
+	, {"path":"/usr/share/inkscape", "read_only":true}
+]
+, "blacklist": [
+]
+, "environment": [
+	{"name":"GTK_THEME", "value":"Adwaita:dark"}
+	, {"name":"GTK2_RC_FILES", "value":"/usr/share/themes/Adwaita-dark/gtk-2.0/gtkrc"}
+]
+, "seccomp": {
+	"mode":"blacklist"
+	, "enforce": true
+}
+}


### PR DESCRIPTION
Evening.

I'm presenting the GIMP and Inkscape profiles that I use. They're based on Dapper Linux's, I modified it slightly to whitelist additional folders such as "~/.fonts", a common location for user installed fonts, and "/usr/share/gimp" where optional plugins downloaded  Debian's repository are installed.

Also, I've added a paxrat profile for GIMP in order to prevent it from being blocked by PAX protection. I though it might as well be published over here, as it is a necessary component for the program and its oz profile even start. Though I might suggest, having a subgraph/contrib-paxrat-conf.d repository as well might be in order.

On the other hand, I've haven't added their respective seccomp profiles, as I don't know how to review them. I could upload a profile generated through watch-mode though, if it is of your interest to analyze it.

Cheers!